### PR TITLE
chore: add release draft workflow

### DIFF
--- a/.github/determine-version.js
+++ b/.github/determine-version.js
@@ -1,5 +1,5 @@
 module.exports = async function (core, context, github) {
-  const iterator = octokit.paginate.iterator(github.rest.repos.listReleases, {
+  const iterator = github.paginate.iterator(github.rest.repos.listReleases, {
     ...context,
     per_page: 100
   });

--- a/.github/determine-version.js
+++ b/.github/determine-version.js
@@ -1,6 +1,7 @@
 module.exports = async function (core, context, github) {
   const iterator = github.paginate.iterator(github.rest.repos.listReleases, {
-    ...context,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
     per_page: 100
   });
 

--- a/.github/determine-version.js
+++ b/.github/determine-version.js
@@ -1,0 +1,17 @@
+module.exports = async function (core, context, github) {
+  const iterator = octokit.paginate.iterator(github.rest.repos.listReleases, {
+    ...context,
+    per_page: 100
+  });
+
+  let minor = 1;
+  const now = new Date();
+  for await (const { data: releases } of iterator) {
+    const relevantReleases = releases.filter(x => x.publishedAt.getFullYear() == now.getFullYear() && !draft);
+    if (relevantReleases.length == 0) break;
+
+    minor += relevantReleases.length;
+  }
+  
+  core.info(`::set-output version=${now.getFullYear()}.${minor}`);
+}

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,20 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&'
+no-changes-template: 'This release contains minor changes and bugfixes.'
+template: |
+  # Release notes
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,18 +16,21 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
         with:
           node-version: 18
       - name: Get current version
         uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
           script: |
             const version = require('./.github/determine-version.js')
             await version(core, context, github)
-      - uses: release-drafter/release-drafter@v5
+      - name: Draft release
+        uses: release-drafter/release-drafter@v5
         with:
           version: ${{ steps.version.outputs.version}}
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,21 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,6 +16,19 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Get current version
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          hcloud-token: ${{ secrets.HCLOUD_TOKEN }}
+          script: |
+            const version = require('./.github/determine-version.js')
+            await version(core, context, github)
       - uses: release-drafter/release-drafter@v5
+        with:
+          version: ${{ steps.version.outputs.version}}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added a workflow that triggers on merge requests and creates a draft release with a changelog. Version consists out of two parts `YEAR.RELEASE` where `RELEASE` is the release number of the current year. The workflow will fail unless we cherry pick the resulting commit into main. 